### PR TITLE
Use $views alias to import MyComponent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://codeberg.org/reesericci/actionview-svelte-handler.git
-  revision: 6c5e8c30649482a77d6e846cd1d64e0d4facefdb
+  revision: ebc44dfb3c97c9de475bd45b9821b14847a51868
   specs:
     actionview-svelte-handler (0.5.7)
       rails (~> 7.0)

--- a/app/views/home/show.html.svelte
+++ b/app/views/home/show.html.svelte
@@ -1,5 +1,5 @@
 <script>
-  import MyComponent from "./MyComponent.html.svelte";
+  import MyComponent from "$views/home/MyComponent.html.svelte";
 
   let text = "my-text"
 </script>


### PR DESCRIPTION
I see the following error when viewing the home page:

    Started GET "/" for 127.0.0.1 at 2024-09-20 12:49:08 +0100
    Processing by HomeController#show as HTML
      Rendering layout layouts/application.html.erb
      Rendering home/show.html.svelte within layouts/application
    ✘ [ERROR] Could not resolve "$views/home/MyComponent.html.svelte"

        app/views/home/show.html.svelte:9:24:
          9 │ import MyComponent from "$views/home/MyComponent.html.svelte";
            ╵                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

      You can mark the path "$views/home/MyComponent.html.svelte" as external to exclude it from the
      bundle, which will remove this error and leave the unresolved path in the bundle.

      Rendered home/show.html.svelte within layouts/application (Duration: 460.6ms | GC: 0.0ms)
      Rendered layout layouts/application.html.erb (Duration: 460.8ms | GC: 0.0ms)
    Completed 500 Internal Server Error in 463ms (ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.1ms)

    ActionView::Template::Error (undefined method `dig' for nil:NilClass):

    Causes:
    NoMethodError (undefined method `dig' for nil:NilClass)

    app/views/home/show.html.svelte:32:in `new'
    app/views/home/show.html.svelte:32