### PR TITLE
Render Svelte component from application layout

### DIFF
--- a/app/views/layouts/_Footer.html.svelte
+++ b/app/views/layouts/_Footer.html.svelte
@@ -1,0 +1,1 @@
+<footer>Footer</footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,4 +21,6 @@
   <body>
     <%= yield %>
   </body>
+
+  <%= render "./Footer" %>
 </html>


### PR DESCRIPTION
I see the following error when viewing the home page:

    Started GET "/" for 127.0.0.1 at 2024-09-20 12:54:55 +0100
    Processing by HomeController#show as HTML
      Rendering layout layouts/application.html.erb
      Rendering home/show.html.svelte within layouts/application
    ""
    ""
      Rendered home/show.html.svelte within layouts/application (Duration: 575.3ms | GC: 0.1ms)
      Rendered layout layouts/application.html.erb (Duration: 577.8ms | GC: 0.1ms)
    Completed 500 Internal Server Error in 580ms (ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.1ms)

    ActionView::Template::Error (Missing partial ./_Footer with {:locale=>[:en], :formats=>[:html], :variants=>[:client, :server], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder, :svelte]}.

    Searched in:
      * "~/Code/freerange/vanilla-rails-v7.2.1-with-actionview-svelte-handler/app/views"
      * "~/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/turbo-rails-2.0.9/app/views" * "~/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/actiontext-7.2.1/app/views" * "~/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/actionmailbox-7.2.1/app/views" ):

    Causes: ActionView::MissingTemplate (Missing partial ./_Footer with {:locale=>[:en], :formats=>[:html], :variants=>[:client, :server], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder, :svelte]}.

    Searched in:
      * "~/Code/freerange/vanilla-rails-v7.2.1-with-actionview-svelte-handler/app/views"
      * "~/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/turbo-rails-2.0.9/app/views" * "~/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/actiontext-7.2.1/app/views" * "~/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/actionmailbox-7.2.1/app/views" )
        22:     <%= yield %>
        23:   </body>
        24:
        25:   <%= render "./Footer" %>
        26: </html>

    app/views/layouts/application.html.erb:25